### PR TITLE
libcifx: Fix version in `cifx.pc.in` file

### DIFF
--- a/libcifx/cifx.pc.in
+++ b/libcifx/cifx.pc.in
@@ -6,6 +6,6 @@ includedir=@includedir@
 Name: libcifx
 Description: Hilscher cifX user space library
 Requires: @REQUIRED_PACKAGES@
-Version: @DRVVERSION@
+Version: @DRV_VERSION@
 Libs: -L@libdir@ -lcifx -lpthread
 Cflags: -I@includedir@/cifx


### PR DESCRIPTION
`cifx.pc.in` is using a variable `DRVVERSION` to populate `Version` field during build. This variable is defined with quotation marks and with `V` before the major number. Instead `DRV_VERSION` variable should be used instead, as it is defined as a `major`.`minor`.`patch` literal.

Additionally, using `"Vx.x.x"` as `Version` creates problem with RPM packaging. `rpmbuild` throws an error:
```
RPM build errors:
    Illegal char '"' (0x22) in: "V3.0.0"
```